### PR TITLE
Bootstrap monorepo with basic engine modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Living-Motion Particle Engine
+
+This repository bootstraps the project described in the vision and tech-stack documents.
+
+The monorepo uses **pnpm** workspaces and contains the following packages:
+
+- `@living-motion/core` – minimal engine kernel with renderer setup.
+- `@living-motion/solvers` – sample solver implementations.
+- `@living-motion/react` – React hook wrapper for easy integration.
+
+Run `pnpm install` then `pnpm test` to execute unit tests.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "living-motion-monorepo",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "lint": "eslint . --ext .ts,.tsx",
+    "typecheck": "tsc -b",
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@living-motion/core",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "dependencies": {
+    "three": "^0.177.0"
+  }
+}

--- a/packages/core/src/ParticleEngine.ts
+++ b/packages/core/src/ParticleEngine.ts
@@ -1,0 +1,41 @@
+import { WebGPURenderer } from 'three/examples/jsm/renderers/WebGPURenderer.js';
+import { PerspectiveCamera, Scene } from 'three';
+import ParticlePool from './ParticlePool.js';
+import Scheduler from './Scheduler.js';
+import UniformBridge from './UniformBridge.js';
+
+export interface EngineOptions {
+  canvas: HTMLCanvasElement;
+  maxParticles?: number;
+}
+
+export default class ParticleEngine {
+  readonly renderer: WebGPURenderer;
+  readonly scene: Scene;
+  readonly camera: PerspectiveCamera;
+  readonly pool: ParticlePool;
+  readonly scheduler: Scheduler;
+  readonly uniformBridge: UniformBridge;
+
+  constructor(opts: EngineOptions) {
+    this.renderer = new WebGPURenderer({ canvas: opts.canvas });
+    this.scene = new Scene();
+    this.camera = new PerspectiveCamera(60, 1, 0.1, 1000);
+    this.pool = new ParticlePool(opts.maxParticles ?? 100000);
+    this.scheduler = new Scheduler();
+    this.uniformBridge = new UniformBridge();
+  }
+
+  start() {
+    const tick = () => {
+      this.scheduler.update();
+      this.renderer.render(this.scene, this.camera);
+      requestAnimationFrame(tick);
+    };
+    tick();
+  }
+
+  dispose() {
+    this.renderer.dispose();
+  }
+}

--- a/packages/core/src/ParticlePool.ts
+++ b/packages/core/src/ParticlePool.ts
@@ -1,0 +1,11 @@
+export default class ParticlePool {
+  capacity: number;
+  position: Float32Array;
+  velocity: Float32Array;
+
+  constructor(capacity: number) {
+    this.capacity = capacity;
+    this.position = new Float32Array(capacity * 3);
+    this.velocity = new Float32Array(capacity * 3);
+  }
+}

--- a/packages/core/src/Scheduler.ts
+++ b/packages/core/src/Scheduler.ts
@@ -1,0 +1,5 @@
+export default class Scheduler {
+  update() {
+    // placeholder for compute passes
+  }
+}

--- a/packages/core/src/UniformBridge.ts
+++ b/packages/core/src/UniformBridge.ts
@@ -1,0 +1,11 @@
+export default class UniformBridge {
+  private topics: Map<string, any> = new Map();
+
+  setTopic<T>(name: string, value: T) {
+    this.topics.set(name, value);
+  }
+
+  getTopic<T>(name: string): T | undefined {
+    return this.topics.get(name) as T | undefined;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,4 @@
+export { default as ParticleEngine } from './ParticleEngine.js';
+export { default as ParticlePool } from './ParticlePool.js';
+export { default as Scheduler } from './Scheduler.js';
+export { default as UniformBridge } from './UniformBridge.js';

--- a/packages/core/test/ParticlePool.test.ts
+++ b/packages/core/test/ParticlePool.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import ParticlePool from '../src/ParticlePool.js';
+
+describe('ParticlePool', () => {
+  it('initializes arrays of correct length', () => {
+    const pool = new ParticlePool(2);
+    expect(pool.position.length).toBe(6);
+    expect(pool.velocity.length).toBe(6);
+  });
+});

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "module": "es2020",
+    "target": "es2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@living-motion/react",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "dependencies": {
+    "@living-motion/core": "0.1.0",
+    "react": "^18.0.0"
+  }
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,0 +1,1 @@
+export { default as useParticleEngine } from './useParticleEngine.js';

--- a/packages/react/src/useParticleEngine.tsx
+++ b/packages/react/src/useParticleEngine.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useRef } from 'react';
+import { ParticleEngine, EngineOptions } from '@living-motion/core';
+
+export default function useParticleEngine(opts: EngineOptions) {
+  const engineRef = useRef<ParticleEngine>();
+  const groupRef = useRef<THREE.Group>(null!);
+
+  useEffect(() => {
+    const canvas = opts.canvas;
+    engineRef.current = new ParticleEngine({ canvas, maxParticles: opts.maxParticles });
+    engineRef.current.start();
+    return () => engineRef.current?.dispose();
+  }, [opts.canvas, opts.maxParticles]);
+
+  return { engine: engineRef.current, groupRef };
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "jsx": "react-jsx",
+    "module": "es2020",
+    "target": "es2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/packages/solvers/package.json
+++ b/packages/solvers/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@living-motion/solvers",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "dependencies": {
+    "@living-motion/core": "0.1.0"
+  }
+}

--- a/packages/solvers/src/SimpleGravity.ts
+++ b/packages/solvers/src/SimpleGravity.ts
@@ -1,0 +1,16 @@
+import { ParticlePool } from '@living-motion/core';
+
+export interface GravityParams {
+  g: number;
+}
+
+export default class SimpleGravity {
+  constructor(private params: GravityParams) {}
+
+  update(pool: ParticlePool, dt: number) {
+    for (let i = 0; i < pool.capacity; i++) {
+      pool.velocity[i * 3 + 1] -= this.params.g * dt;
+      pool.position[i * 3 + 1] += pool.velocity[i * 3 + 1] * dt;
+    }
+  }
+}

--- a/packages/solvers/src/index.ts
+++ b/packages/solvers/src/index.ts
@@ -1,0 +1,1 @@
+export { default as SimpleGravity } from './SimpleGravity.js';

--- a/packages/solvers/tsconfig.json
+++ b/packages/solvers/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "module": "es2020",
+    "target": "es2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    { "path": "packages/core" },
+    { "path": "packages/solvers" },
+    { "path": "packages/react" }
+  ]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['packages/**/*.{test,spec}.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- set up pnpm workspace and basic package configuration
- implement minimal core engine classes
- add a simple solver and React hook
- provide Vitest configuration with initial unit test
- document repository setup

## Testing
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_685e611319ac8327a479970623057c13