### PR TITLE
Add scheduler steps API

### DIFF
--- a/packages/core/src/ParticleEngine.ts
+++ b/packages/core/src/ParticleEngine.ts
@@ -17,6 +17,10 @@ export default class ParticleEngine {
   readonly scheduler: Scheduler;
   readonly uniformBridge: UniformBridge;
 
+  addSolver(solver: { update(pool: ParticlePool, dt: number): void }) {
+    this.scheduler.add((dt) => solver.update(this.pool, dt));
+  }
+
   constructor(opts: EngineOptions) {
     this.renderer = new WebGPURenderer({ canvas: opts.canvas });
     this.scene = new Scene();

--- a/packages/core/src/Scheduler.ts
+++ b/packages/core/src/Scheduler.ts
@@ -1,5 +1,26 @@
+export type Step = (dt: number) => void;
+
 export default class Scheduler {
+  private steps: Step[] = [];
+  private lastTime = performance.now();
+
+  add(step: Step) {
+    this.steps.push(step);
+  }
+
+  remove(step: Step) {
+    const idx = this.steps.indexOf(step);
+    if (idx !== -1) {
+      this.steps.splice(idx, 1);
+    }
+  }
+
   update() {
-    // placeholder for compute passes
+    const now = performance.now();
+    const dt = (now - this.lastTime) / 1000;
+    this.lastTime = now;
+    for (const step of this.steps) {
+      step(dt);
+    }
   }
 }

--- a/packages/core/test/Scheduler.test.ts
+++ b/packages/core/test/Scheduler.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi } from 'vitest';
+import Scheduler from '../src/Scheduler.js';
+
+describe('Scheduler', () => {
+  it('runs steps with delta time', () => {
+    const scheduler = new Scheduler();
+    const fn = vi.fn();
+    scheduler.add(fn);
+    scheduler.update();
+    expect(fn).toHaveBeenCalled();
+    const dt = fn.mock.calls[0][0];
+    expect(typeof dt).toBe('number');
+  });
+});


### PR DESCRIPTION
## Summary
- implement a basic step scheduler
- expose `addSolver` in `ParticleEngine`
- test scheduler behaviour

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7096c1b483278e3bd4520d1ceb00