### PR TITLE
Add additional packages from vision docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ The monorepo uses **pnpm** workspaces and contains the following packages:
 - `@living-motion/core` – minimal engine kernel with renderer setup.
 - `@living-motion/solvers` – sample solver implementations.
 - `@living-motion/emitters` – basic particle emitters.
+- `@living-motion/fields` – simple force field utilities.
+- `@living-motion/materials` – helpers for Three.js materials.
+- `@living-motion/post` – small postprocessing passes.
 - `@living-motion/react` – React hook wrapper for easy integration.
 
 Run `pnpm install` then `pnpm test` to execute unit tests.

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@living-motion/fields",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "dependencies": {
+    "@living-motion/core": "0.1.0"
+  }
+}

--- a/packages/fields/src/CurlNoiseField.ts
+++ b/packages/fields/src/CurlNoiseField.ts
@@ -1,0 +1,26 @@
+import { ParticlePool } from '@living-motion/core';
+
+export interface CurlNoiseOptions {
+  scale: number;
+}
+
+export default class CurlNoiseField {
+  constructor(private opts: CurlNoiseOptions) {}
+
+  private noise3d(x: number, y: number, z: number): number {
+    const s = Math.sin(x * 12.9898 + y * 78.233 + z * 37.719);
+    return s - Math.floor(s);
+  }
+
+  update(pool: ParticlePool, dt: number) {
+    const { scale } = this.opts;
+    for (let i = 0; i < pool.count; i++) {
+      const px = pool.position[i * 3];
+      const py = pool.position[i * 3 + 1];
+      const pz = pool.position[i * 3 + 2];
+      const n = this.noise3d(px * scale, py * scale, pz * scale);
+      pool.velocity[i * 3] += Math.cos(n * Math.PI * 2) * dt;
+      pool.velocity[i * 3 + 1] += Math.sin(n * Math.PI * 2) * dt;
+    }
+  }
+}

--- a/packages/fields/src/DipoleField.ts
+++ b/packages/fields/src/DipoleField.ts
@@ -1,0 +1,31 @@
+import { ParticlePool } from '@living-motion/core';
+
+export interface DipoleFieldOptions {
+  strength: number;
+  posA: [number, number, number];
+  posB: [number, number, number];
+}
+
+export default class DipoleField {
+  constructor(private opts: DipoleFieldOptions) {}
+
+  update(pool: ParticlePool, dt: number) {
+    const { strength, posA, posB } = this.opts;
+    for (let i = 0; i < pool.count; i++) {
+      const x = pool.position[i * 3];
+      const y = pool.position[i * 3 + 1];
+      const z = pool.position[i * 3 + 2];
+      const ax = x - posA[0];
+      const ay = y - posA[1];
+      const az = z - posA[2];
+      const bx = x - posB[0];
+      const by = y - posB[1];
+      const bz = z - posB[2];
+      const aDistSq = ax * ax + ay * ay + az * az + 1e-6;
+      const bDistSq = bx * bx + by * by + bz * bz + 1e-6;
+      pool.velocity[i * 3] += (-ax / aDistSq + bx / bDistSq) * strength * dt;
+      pool.velocity[i * 3 + 1] += (-ay / aDistSq + by / bDistSq) * strength * dt;
+      pool.velocity[i * 3 + 2] += (-az / aDistSq + bz / bDistSq) * strength * dt;
+    }
+  }
+}

--- a/packages/fields/src/SDFGradientField.ts
+++ b/packages/fields/src/SDFGradientField.ts
@@ -1,0 +1,33 @@
+import { ParticlePool } from '@living-motion/core';
+
+export type SDF = (x: number, y: number, z: number) => number;
+
+export interface SDFGradientFieldOptions {
+  sdf: SDF;
+  strength: number;
+}
+
+export default class SDFGradientField {
+  constructor(private opts: SDFGradientFieldOptions) {}
+
+  private gradient(x: number, y: number, z: number, h = 0.01) {
+    const { sdf } = this.opts;
+    const dx = sdf(x + h, y, z) - sdf(x - h, y, z);
+    const dy = sdf(x, y + h, z) - sdf(x, y - h, z);
+    const dz = sdf(x, y, z + h) - sdf(x, y, z - h);
+    return [dx / (2 * h), dy / (2 * h), dz / (2 * h)] as const;
+  }
+
+  update(pool: ParticlePool, dt: number) {
+    const { strength } = this.opts;
+    for (let i = 0; i < pool.count; i++) {
+      const x = pool.position[i * 3];
+      const y = pool.position[i * 3 + 1];
+      const z = pool.position[i * 3 + 2];
+      const [gx, gy, gz] = this.gradient(x, y, z);
+      pool.velocity[i * 3] += gx * strength * dt;
+      pool.velocity[i * 3 + 1] += gy * strength * dt;
+      pool.velocity[i * 3 + 2] += gz * strength * dt;
+    }
+  }
+}

--- a/packages/fields/src/index.ts
+++ b/packages/fields/src/index.ts
@@ -1,0 +1,3 @@
+export { default as CurlNoiseField } from './CurlNoiseField.js';
+export { default as DipoleField } from './DipoleField.js';
+export { default as SDFGradientField } from './SDFGradientField.js';

--- a/packages/fields/tsconfig.json
+++ b/packages/fields/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "module": "es2020",
+    "target": "es2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/packages/materials/package.json
+++ b/packages/materials/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@living-motion/materials",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "dependencies": {
+    "three": "^0.177.0"
+  }
+}

--- a/packages/materials/src/PointsMaterialFactory.ts
+++ b/packages/materials/src/PointsMaterialFactory.ts
@@ -1,0 +1,14 @@
+import { PointsMaterial } from 'three';
+
+export interface PointsMaterialOptions {
+  color?: number;
+  size?: number;
+}
+
+export default function PointsMaterialFactory(opts: PointsMaterialOptions = {}) {
+  return new PointsMaterial({
+    color: opts.color ?? 0xffffff,
+    size: opts.size ?? 1,
+    sizeAttenuation: true,
+  });
+}

--- a/packages/materials/src/RibbonMaterialFactory.ts
+++ b/packages/materials/src/RibbonMaterialFactory.ts
@@ -1,0 +1,5 @@
+import { LineBasicMaterial } from 'three';
+
+export default function RibbonMaterialFactory() {
+  return new LineBasicMaterial({ color: 0xffffff });
+}

--- a/packages/materials/src/VolumeMaterialFactory.ts
+++ b/packages/materials/src/VolumeMaterialFactory.ts
@@ -1,0 +1,8 @@
+import { ShaderMaterial } from 'three';
+
+export default function VolumeMaterialFactory() {
+  return new ShaderMaterial({
+    transparent: true,
+    depthWrite: false,
+  });
+}

--- a/packages/materials/src/index.ts
+++ b/packages/materials/src/index.ts
@@ -1,0 +1,3 @@
+export { default as PointsMaterialFactory } from './PointsMaterialFactory.js';
+export { default as VolumeMaterialFactory } from './VolumeMaterialFactory.js';
+export { default as RibbonMaterialFactory } from './RibbonMaterialFactory.js';

--- a/packages/materials/tsconfig.json
+++ b/packages/materials/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "module": "es2020",
+    "target": "es2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/packages/post/package.json
+++ b/packages/post/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@living-motion/post",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "dependencies": {
+    "three": "^0.177.0"
+  }
+}

--- a/packages/post/src/BloomNodePass.ts
+++ b/packages/post/src/BloomNodePass.ts
@@ -1,0 +1,16 @@
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
+import type { Scene, Camera, Vector2 } from 'three';
+
+export default class BloomNodePass {
+  readonly pass: UnrealBloomPass;
+  constructor(resolution: Vector2 = new Vector2(1024, 1024), strength = 1, radius = 0.4, threshold = 0) {
+    this.pass = new UnrealBloomPass(resolution, strength, radius, threshold);
+  }
+
+  apply(composer: EffectComposer, scene: Scene, camera: Camera) {
+    composer.addPass(new RenderPass(scene, camera));
+    composer.addPass(this.pass);
+  }
+}

--- a/packages/post/src/DOFNodePass.ts
+++ b/packages/post/src/DOFNodePass.ts
@@ -1,0 +1,19 @@
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+import { BokehPass } from 'three/examples/jsm/postprocessing/BokehPass.js';
+import type { Scene, Camera } from 'three';
+
+export interface DOFOptions {
+  focus: number;
+  aperture: number;
+  maxblur: number;
+}
+
+export default class DOFNodePass {
+  readonly pass: BokehPass;
+  constructor(scene: Scene, camera: Camera, opts: DOFOptions) {
+    this.pass = new BokehPass(scene, camera, opts);
+  }
+  apply(composer: EffectComposer) {
+    composer.addPass(this.pass);
+  }
+}

--- a/packages/post/src/MotionBlurNodePass.ts
+++ b/packages/post/src/MotionBlurNodePass.ts
@@ -1,0 +1,12 @@
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+import { AfterimagePass } from 'three/examples/jsm/postprocessing/AfterimagePass.js';
+
+export default class MotionBlurNodePass {
+  readonly pass: AfterimagePass;
+  constructor(damp = 0.96) {
+    this.pass = new AfterimagePass(damp);
+  }
+  apply(composer: EffectComposer) {
+    composer.addPass(this.pass);
+  }
+}

--- a/packages/post/src/index.ts
+++ b/packages/post/src/index.ts
@@ -1,0 +1,3 @@
+export { default as BloomNodePass } from './BloomNodePass.js';
+export { default as MotionBlurNodePass } from './MotionBlurNodePass.js';
+export { default as DOFNodePass } from './DOFNodePass.js';

--- a/packages/post/tsconfig.json
+++ b/packages/post/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "module": "es2020",
+    "target": "es2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,9 @@
     { "path": "packages/core" },
     { "path": "packages/solvers" },
     { "path": "packages/react" },
-    { "path": "packages/emitters" }
+    { "path": "packages/emitters" },
+    { "path": "packages/fields" },
+    { "path": "packages/materials" },
+    { "path": "packages/post" }
   ]
 }


### PR DESCRIPTION
## Summary
- add `@living-motion/fields` with CurlNoise, Dipole and SDF gradient fields
- add `@living-motion/materials` with simple material factory helpers
- add `@living-motion/post` with basic bloom, motion‑blur and DOF passes
- update TypeScript project references
- document new packages in README

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e85b333c08327a115d3dc39578e1f