### PR TITLE
Align with latest Three.js node system

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This repository bootstraps the project described in the vision and tech-stack documents.
 
-The monorepo uses **pnpm** workspaces and contains the following packages:
+The monorepo targets **Three.js r178** and uses **WebGPURenderer** from `three/webgpu`.
+It uses **pnpm** workspaces and contains the following packages:
 
 - `@living-motion/core` – minimal engine kernel with renderer setup.
 - `@living-motion/solvers` – sample solver implementations.
@@ -11,5 +12,8 @@ The monorepo uses **pnpm** workspaces and contains the following packages:
 - `@living-motion/materials` – helpers for Three.js materials.
 - `@living-motion/post` – small postprocessing passes.
 - `@living-motion/react` – React hook wrapper for easy integration.
+
+The core engine requires calling `init()` on `ParticleEngine` before `start()`. The
+React hook `useParticleEngine` handles this automatically.
 
 Run `pnpm install` then `pnpm test` to execute unit tests.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,6 @@
     "build": "tsc -b"
   },
   "dependencies": {
-    "three": "^0.177.0"
+    "three": "^0.178.0"
   }
 }

--- a/packages/core/src/ParticleEngine.ts
+++ b/packages/core/src/ParticleEngine.ts
@@ -1,4 +1,4 @@
-import { WebGPURenderer } from 'three/examples/jsm/renderers/WebGPURenderer.js';
+import { WebGPURenderer } from 'three/webgpu';
 import { PerspectiveCamera, Scene } from 'three';
 import ParticlePool from './ParticlePool.js';
 import Scheduler from './Scheduler.js';
@@ -36,6 +36,10 @@ export default class ParticleEngine {
     this.pool = new ParticlePool(opts.maxParticles ?? 100000);
     this.scheduler = new Scheduler();
     this.uniformBridge = new UniformBridge();
+  }
+
+  async init() {
+    await this.renderer.init();
   }
 
   start() {

--- a/packages/materials/package.json
+++ b/packages/materials/package.json
@@ -14,6 +14,6 @@
     "build": "tsc -b"
   },
   "dependencies": {
-    "three": "^0.177.0"
+    "three": "^0.178.0"
   }
 }

--- a/packages/post/package.json
+++ b/packages/post/package.json
@@ -14,6 +14,6 @@
     "build": "tsc -b"
   },
   "dependencies": {
-    "three": "^0.177.0"
+    "three": "^0.178.0"
   }
 }

--- a/packages/react/src/useParticleEngine.tsx
+++ b/packages/react/src/useParticleEngine.tsx
@@ -8,7 +8,7 @@ export default function useParticleEngine(opts: EngineOptions) {
   useEffect(() => {
     const canvas = opts.canvas;
     engineRef.current = new ParticleEngine({ canvas, maxParticles: opts.maxParticles });
-    engineRef.current.start();
+    engineRef.current.init().then(() => engineRef.current?.start());
     return () => engineRef.current?.dispose();
   }, [opts.canvas, opts.maxParticles]);
 


### PR DESCRIPTION
## Summary
- update README to mention WebGPURenderer and initialization
- use `three/webgpu` and add async init to `ParticleEngine`
- handle engine init in `useParticleEngine`
- bump Three.js dependency to `^0.178.0`

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687532fa6a488327b948898d4daff6f1